### PR TITLE
remove babel-rc add an svg react component that works isomorphically

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,0 @@
-{
-    "presets": [
-        "es2015",
-        "stage-2",
-        "react"
-    ]
-}

--- a/js/SvgStringToReact.jsx
+++ b/js/SvgStringToReact.jsx
@@ -1,0 +1,29 @@
+const React = require('react');
+const { PropTypes } = React;
+
+const SvgStringToReact = React.createClass({
+    propTypes: {
+        svg: PropTypes.string,
+        styles: PropTypes.object,
+        width: PropTypes.number,
+        height: PropTypes.number
+    },
+    render() {
+        let styles = {
+            fill: "currentcolor",
+            verticalAlign: "middle"
+        };
+        return (
+            <svg 
+                viewBox="0 0 24 24"
+                width={this.props.width}
+                height={this.props.height || this.props.width}
+                preserveAspectRatio="xMidYMid meet"
+                fit
+                style= {Object.assign({}, styles, this.props.style)}
+                dangerouslySetInnerHTML={{__html: this.props.svg}} />
+        );
+    }
+});
+
+module.exports = SvgStringToReact;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
     devtool : 'source-map',
     module : {
         loaders: [
-            { test: /\.(js|jsx|svg)$/, loader: 'babel'}, //, query: { presets: ['babel-preset-es2015', 'babel-preset-stage-2', 'babel-preset-react']}
+            { test: /\.(js|jsx|svg)$/, loader: 'babel', query: { "presets": ["es2015", "stage-2", "react"]} },
             { test: /\.svg$/, loader: 'svg-react' },
             { test: /\.json/, loader: 'json' },
             { test: /\.scss/, loaders: ["style", "css", "sass"] }


### PR DESCRIPTION
The webpack way does not work on node.  this allows react to expect the svg as a string. 